### PR TITLE
Fix version name in __init__.py

### DIFF
--- a/plexiglass/__init__.py
+++ b/plexiglass/__init__.py
@@ -1,5 +1,5 @@
 import os
 from . import adversarial
 from . import detectors
-with open(os.path.join(os.path.dirname(__file__), 'VERSION')) as f:
+with open(os.path.join(os.path.dirname(__file__), 'version')) as f:
     __version__ = f.read().strip()


### PR DESCRIPTION
Version file was incorrectly named in the __init__.py file of the plexiglass package.